### PR TITLE
Removed TOKEN_CONS unused variable in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 SPTRANS_TOKEN= #### Token #####
-TOKEN_CONS= #### Token #####
 FACEBOOK_APP_ID= #### Token ####
 FACEBOOK_APP_SECRET= #### Token ####


### PR DESCRIPTION
Não existe mais nada fazendo referência dessa variável no código.